### PR TITLE
Animate selected progress rings

### DIFF
--- a/app/src/main/java/com/mgruchala/drinkwise/navigaiton/AppNavigation.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/navigaiton/AppNavigation.kt
@@ -10,6 +10,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -30,6 +33,8 @@ import com.mgruchala.drinkwise.presentation.settings.SettingsScreen
 @Composable
 fun AppNavigation() {
     val navController = rememberNavController()
+    var homeInitialProgressAnimationShown by rememberSaveable { mutableStateOf(false) }
+    var calendarInitialProgressAnimationShown by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0),
@@ -80,9 +85,20 @@ fun AppNavigation() {
                 .padding(innerPadding)
                 .consumeWindowInsets(innerPadding)
         ) {
-            composable(AppRoute.Home.name) { HomeScreen() }
+            composable(AppRoute.Home.name) {
+                HomeScreen(
+                    animateInitialProgress = !homeInitialProgressAnimationShown,
+                    onInitialProgressAnimationConsumed = {
+                        homeInitialProgressAnimationShown = true
+                    }
+                )
+            }
             composable(AppRoute.Calendar.name) {
                 CalendarScreen(
+                    animateInitialProgress = !calendarInitialProgressAnimationShown,
+                    onInitialProgressAnimationConsumed = {
+                        calendarInitialProgressAnimationShown = true
+                    },
                     onDayClick = { date ->
                         navController.navigate(AppRoute.DayDetails.createRoute(date.toEpochDay()))
                     }

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/calendar/CalendarScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -71,7 +72,9 @@ private val PreviewToday: LocalDate = LocalDate.of(2026, 5, 21)
 @Composable
 fun CalendarScreen(
     onDayClick: (LocalDate) -> Unit = {},
-    viewModel: CalendarViewModel = hiltViewModel()
+    viewModel: CalendarViewModel = hiltViewModel(),
+    animateInitialProgress: Boolean = true,
+    onInitialProgressAnimationConsumed: () -> Unit = {}
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
@@ -84,6 +87,8 @@ fun CalendarScreen(
             calendarData = state.calendarData,
             monthlyAlcoholUnitLevels = state.monthlyAlcoholUnitLevels,
             today = state.today,
+            animateInitialProgress = animateInitialProgress,
+            onInitialProgressAnimationConsumed = onInitialProgressAnimationConsumed,
             onDayClick = onDayClick
         )
     }
@@ -94,12 +99,23 @@ fun CalendarScreenContent(
     calendarData: Map<YearMonth, List<CalendarDayData>>,
     monthlyAlcoholUnitLevels: Map<YearMonth, AlcoholUnitLevel> = emptyMap(),
     today: LocalDate,
-    onDayClick: (LocalDate) -> Unit = {}
+    onDayClick: (LocalDate) -> Unit = {},
+    animateInitialProgress: Boolean = true,
+    onInitialProgressAnimationConsumed: () -> Unit = {}
 ) {
     val sortedMonths = calendarData.keys.sortedDescending()
     val initialPage = 0
     val pagerState = rememberPagerState(initialPage = initialPage) { sortedMonths.size }
     val coroutineScope = rememberCoroutineScope()
+    val currentMonthHasSummary = sortedMonths
+        .firstOrNull()
+        ?.let { month -> monthlyAlcoholUnitLevels.containsKey(month) } == true
+
+    LaunchedEffect(animateInitialProgress, currentMonthHasSummary) {
+        if (animateInitialProgress && currentMonthHasSummary) {
+            onInitialProgressAnimationConsumed()
+        }
+    }
 
     Scaffold { innerPadding ->
         Column(
@@ -147,7 +163,10 @@ fun CalendarScreenContent(
                             modifier = Modifier.fillMaxWidth(),
                             contentAlignment = Alignment.Center
                         ) {
-                            MonthConsumptionIndicator(alcoholUnitLevel = monthAlcoholUnitLevel)
+                            MonthConsumptionIndicator(
+                                alcoholUnitLevel = monthAlcoholUnitLevel,
+                                animateInitialProgress = animateInitialProgress
+                            )
                         }
                         Spacer(modifier = Modifier.height(MonthConsumptionIndicatorBottomGap))
                     }
@@ -307,7 +326,8 @@ fun WeekRow(
 @Composable
 fun MonthConsumptionIndicator(
     alcoholUnitLevel: AlcoholUnitLevel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    animateInitialProgress: Boolean = true
 ) {
     val consumed = alcoholUnitLevel.unitCount
     val limit = calculateAlcoholUnitIndicatorSafeLimit(alcoholUnitLevel.limit)
@@ -349,7 +369,8 @@ fun MonthConsumptionIndicator(
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
             strokeWidth = MonthConsumptionIndicatorStrokeWidth,
             modifier = Modifier.fillMaxSize(),
-            animateProgress = true
+            animateProgress = true,
+            animateInitialProgress = animateInitialProgress
         )
 
         Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/calendar/CalendarScreen.kt
@@ -348,7 +348,8 @@ fun MonthConsumptionIndicator(
             alcoholUnitLevel = alcoholUnitLevel,
             trackColor = MaterialTheme.colorScheme.surfaceVariant,
             strokeWidth = MonthConsumptionIndicatorStrokeWidth,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
+            animateProgress = true
         )
 
         Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
@@ -8,7 +8,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -33,7 +36,8 @@ private const val StartAngleDegrees = -90f
 private const val MinimumAlcoholUnitIndicatorLimit = 0.1f
 private const val DayDetailsIndicatorDiameter = 220f
 private const val DayDetailsOverflowGapPadding = 4f
-private const val AlcoholUnitProgressRingAnimationDurationMillis = 800
+private const val AlcoholUnitProgressRingAnimationDurationMillis = 1_200
+private const val AlcoholUnitProgressRingAnimationStartDelayMillis = 300
 private val AlcoholUnitProgressRingAnimationEasing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
 
 // Extra clear radius as a fraction of indicator diameter; 4dp on the 220dp details ring.
@@ -79,6 +83,19 @@ internal fun resolveAlcoholUnitIndicatorDrawRatio(
     return if (animateProgress) animatedRatio else targetRatio
 }
 
+internal fun calculateAlcoholUnitIndicatorAnimationDurationMillis(
+    animationDurationMillis: Int
+): Int {
+    return animationDurationMillis.coerceAtLeast(0)
+}
+
+internal fun calculateAlcoholUnitIndicatorInitialAnimationDelayMillis(
+    animationStartDelayMillis: Int,
+    isInitialAnimation: Boolean
+): Int {
+    return if (isInitialAnimation) animationStartDelayMillis.coerceAtLeast(0) else 0
+}
+
 internal fun alcoholUnitLevelIndicatorColor(alcoholUnitLevel: AlcoholUnitLevel): Color {
     return when (alcoholUnitLevel) {
         is AlcoholUnitLevel.Low -> AlcoholUnitLevelLow
@@ -94,24 +111,41 @@ internal fun AlcoholUnitProgressRing(
     trackColor: Color = MaterialTheme.colorScheme.inverseSurface,
     strokeWidth: Dp = 5.dp,
     overflowGapPaddingFraction: Float = AlcoholUnitIndicatorDefaultOverflowGapPaddingFraction,
-    animateProgress: Boolean = false
+    animateProgress: Boolean = false,
+    animationDurationMillis: Int = AlcoholUnitProgressRingAnimationDurationMillis,
+    animationStartDelayMillis: Int = AlcoholUnitProgressRingAnimationStartDelayMillis
 ) {
     val targetRatio = calculateAlcoholUnitIndicatorRatio(
         unitCount = alcoholUnitLevel.unitCount,
         limit = alcoholUnitLevel.limit
     )
     val animatedRatio = remember { Animatable(0f) }
+    var isInitialAnimation by remember { mutableStateOf(true) }
 
-    LaunchedEffect(animateProgress, targetRatio) {
+    LaunchedEffect(
+        animateProgress,
+        targetRatio,
+        animationDurationMillis,
+        animationStartDelayMillis
+    ) {
         if (animateProgress) {
+            val initialDelayMillis = calculateAlcoholUnitIndicatorInitialAnimationDelayMillis(
+                animationStartDelayMillis = animationStartDelayMillis,
+                isInitialAnimation = isInitialAnimation
+            )
+            isInitialAnimation = false
             animatedRatio.animateTo(
                 targetValue = targetRatio,
                 animationSpec = tween(
-                    durationMillis = AlcoholUnitProgressRingAnimationDurationMillis,
+                    durationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
+                        animationDurationMillis = animationDurationMillis
+                    ),
+                    delayMillis = initialDelayMillis,
                     easing = AlcoholUnitProgressRingAnimationEasing
                 )
             )
         } else {
+            isInitialAnimation = false
             animatedRatio.snapTo(targetRatio)
         }
     }

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
@@ -47,9 +47,9 @@ private const val StartAngleDegrees = -90f
 private const val MinimumAlcoholUnitIndicatorLimit = 0.1f
 private const val DayDetailsIndicatorDiameter = 220f
 private const val DayDetailsOverflowGapPadding = 4f
-private const val AlcoholUnitProgressRingAnimationDurationMillis = 650
-private const val AlcoholUnitProgressRingAnimationDurationPerRatioMillis = 700
-private const val AlcoholUnitProgressRingAnimationStartDelayMillis = 300
+private const val AlcoholUnitProgressRingAnimationDurationMillis = 700
+private const val AlcoholUnitProgressRingAnimationDurationPerRatioMillis = 800
+private const val AlcoholUnitProgressRingAnimationStartDelayMillis = 350
 private val AlcoholUnitProgressRingAnimationEasing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
 
 // Extra clear radius as a fraction of indicator diameter; 4dp on the 220dp details ring.

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
@@ -47,7 +47,7 @@ private const val StartAngleDegrees = -90f
 private const val MinimumAlcoholUnitIndicatorLimit = 0.1f
 private const val DayDetailsIndicatorDiameter = 220f
 private const val DayDetailsOverflowGapPadding = 4f
-private const val AlcoholUnitProgressRingAnimationDurationMillis = 700
+private const val AlcoholUnitProgressRingAnimationDurationMillis = 800
 private const val AlcoholUnitProgressRingAnimationDurationPerRatioMillis = 800
 private const val AlcoholUnitProgressRingAnimationStartDelayMillis = 350
 private val AlcoholUnitProgressRingAnimationEasing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
@@ -95,6 +95,22 @@ internal fun resolveAlcoholUnitIndicatorDrawRatio(
     return if (animateProgress) animatedRatio else targetRatio
 }
 
+internal fun resolveAlcoholUnitIndicatorInitialAnimatedRatio(
+    targetRatio: Float,
+    animateProgress: Boolean,
+    animateInitialProgress: Boolean
+): Float {
+    return if (animateProgress && animateInitialProgress) 0f else targetRatio
+}
+
+internal fun shouldAnimateAlcoholUnitIndicatorTransition(
+    animateProgress: Boolean,
+    animateInitialProgress: Boolean,
+    isInitialAnimation: Boolean
+): Boolean {
+    return animateProgress && (!isInitialAnimation || animateInitialProgress)
+}
+
 internal fun calculateAlcoholUnitIndicatorAnimationDurationMillis(
     animationDurationMillis: Int,
     animationDurationPerRatioMillis: Int,
@@ -126,14 +142,15 @@ internal fun alcoholUnitLevelIndicatorColor(alcoholUnitLevel: AlcoholUnitLevel):
 /**
  * Draws the shared alcohol unit progress ring.
  *
- * Progress animation is opt-in. When [animateProgress] is enabled, the ring animates the
- * displayed ratio while text and semantics in parent components can continue showing the final
- * value. A ratio of `1f` means the configured limit; values above `1f` move through the same
- * over-limit renderer used by static rings, including the cleared overflow gap.
+ * Progress animation is opt-in. When [animateProgress] is enabled, later target changes animate
+ * from the current displayed ratio while text and semantics in parent components can continue
+ * showing the final value. A ratio of `1f` means the configured limit; values above `1f` move
+ * through the same over-limit renderer used by static rings, including the cleared overflow gap.
  *
- * On first composition, the animated ratio starts at zero and waits [animationStartDelayMillis]
- * before drawing to the target. Later target changes start immediately from the current displayed
- * ratio. The duration for each transition is:
+ * When [animateInitialProgress] is enabled, first composition starts at zero and waits
+ * [animationStartDelayMillis] before drawing to the target. When it is disabled, first composition
+ * snaps to the target, but later target changes still animate if [animateProgress] is enabled.
+ * The duration for each animated transition is:
  *
  * `animationDurationMillis + animationDurationPerRatioMillis * abs(targetRatio - currentRatio)`.
  *
@@ -149,6 +166,7 @@ internal fun AlcoholUnitProgressRing(
     strokeWidth: Dp = 5.dp,
     overflowGapPaddingFraction: Float = AlcoholUnitIndicatorDefaultOverflowGapPaddingFraction,
     animateProgress: Boolean = false,
+    animateInitialProgress: Boolean = animateProgress,
     animationDurationMillis: Int = AlcoholUnitProgressRingAnimationDurationMillis,
     animationDurationPerRatioMillis: Int = AlcoholUnitProgressRingAnimationDurationPerRatioMillis,
     animationStartDelayMillis: Int = AlcoholUnitProgressRingAnimationStartDelayMillis
@@ -157,7 +175,15 @@ internal fun AlcoholUnitProgressRing(
         unitCount = alcoholUnitLevel.unitCount,
         limit = alcoholUnitLevel.limit
     )
-    val animatedRatio = remember { Animatable(0f) }
+    val animatedRatio = remember {
+        Animatable(
+            resolveAlcoholUnitIndicatorInitialAnimatedRatio(
+                targetRatio = targetRatio,
+                animateProgress = animateProgress,
+                animateInitialProgress = animateInitialProgress
+            )
+        )
+    }
     var isInitialAnimation by remember { mutableStateOf(true) }
 
     LaunchedEffect(
@@ -167,10 +193,18 @@ internal fun AlcoholUnitProgressRing(
         animationDurationPerRatioMillis,
         animationStartDelayMillis
     ) {
-        if (animateProgress) {
+        val wasInitialAnimation = isInitialAnimation
+        val shouldAnimateTransition = shouldAnimateAlcoholUnitIndicatorTransition(
+            animateProgress = animateProgress,
+            animateInitialProgress = animateInitialProgress,
+            isInitialAnimation = wasInitialAnimation
+        )
+        isInitialAnimation = false
+
+        if (shouldAnimateTransition) {
             val initialDelayMillis = calculateAlcoholUnitIndicatorInitialAnimationDelayMillis(
                 animationStartDelayMillis = animationStartDelayMillis,
-                isInitialAnimation = isInitialAnimation
+                isInitialAnimation = wasInitialAnimation && animateInitialProgress
             )
             val durationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
                 animationDurationMillis = animationDurationMillis,
@@ -188,7 +222,6 @@ internal fun AlcoholUnitProgressRing(
                 )
             )
         } else {
-            isInitialAnimation = false
             animatedRatio.snapTo(targetRatio)
         }
     }

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
@@ -27,16 +27,19 @@ import com.mgruchala.drinkwise.domain.AlcoholUnitLevel
 import com.mgruchala.drinkwise.presentation.theme.AlcoholUnitLevelAlarming
 import com.mgruchala.drinkwise.presentation.theme.AlcoholUnitLevelHigh
 import com.mgruchala.drinkwise.presentation.theme.AlcoholUnitLevelLow
+import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.floor
 import kotlin.math.min
+import kotlin.math.roundToInt
 import kotlin.math.sin
 
 private const val StartAngleDegrees = -90f
 private const val MinimumAlcoholUnitIndicatorLimit = 0.1f
 private const val DayDetailsIndicatorDiameter = 220f
 private const val DayDetailsOverflowGapPadding = 4f
-private const val AlcoholUnitProgressRingAnimationDurationMillis = 1_200
+private const val AlcoholUnitProgressRingAnimationDurationMillis = 650
+private const val AlcoholUnitProgressRingAnimationDurationPerRatioMillis = 700
 private const val AlcoholUnitProgressRingAnimationStartDelayMillis = 300
 private val AlcoholUnitProgressRingAnimationEasing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
 
@@ -84,9 +87,16 @@ internal fun resolveAlcoholUnitIndicatorDrawRatio(
 }
 
 internal fun calculateAlcoholUnitIndicatorAnimationDurationMillis(
-    animationDurationMillis: Int
+    animationDurationMillis: Int,
+    animationDurationPerRatioMillis: Int,
+    startRatio: Float,
+    targetRatio: Float
 ): Int {
-    return animationDurationMillis.coerceAtLeast(0)
+    val baseDurationMillis = animationDurationMillis.coerceAtLeast(0)
+    val durationPerRatioMillis = animationDurationPerRatioMillis.coerceAtLeast(0)
+    val ratioDistance = abs(targetRatio - startRatio)
+
+    return baseDurationMillis + (durationPerRatioMillis * ratioDistance).roundToInt()
 }
 
 internal fun calculateAlcoholUnitIndicatorInitialAnimationDelayMillis(
@@ -113,6 +123,7 @@ internal fun AlcoholUnitProgressRing(
     overflowGapPaddingFraction: Float = AlcoholUnitIndicatorDefaultOverflowGapPaddingFraction,
     animateProgress: Boolean = false,
     animationDurationMillis: Int = AlcoholUnitProgressRingAnimationDurationMillis,
+    animationDurationPerRatioMillis: Int = AlcoholUnitProgressRingAnimationDurationPerRatioMillis,
     animationStartDelayMillis: Int = AlcoholUnitProgressRingAnimationStartDelayMillis
 ) {
     val targetRatio = calculateAlcoholUnitIndicatorRatio(
@@ -126,6 +137,7 @@ internal fun AlcoholUnitProgressRing(
         animateProgress,
         targetRatio,
         animationDurationMillis,
+        animationDurationPerRatioMillis,
         animationStartDelayMillis
     ) {
         if (animateProgress) {
@@ -133,13 +145,17 @@ internal fun AlcoholUnitProgressRing(
                 animationStartDelayMillis = animationStartDelayMillis,
                 isInitialAnimation = isInitialAnimation
             )
+            val durationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
+                animationDurationMillis = animationDurationMillis,
+                animationDurationPerRatioMillis = animationDurationPerRatioMillis,
+                startRatio = animatedRatio.value,
+                targetRatio = targetRatio
+            )
             isInitialAnimation = false
             animatedRatio.animateTo(
                 targetValue = targetRatio,
                 animationSpec = tween(
-                    durationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
-                        animationDurationMillis = animationDurationMillis
-                    ),
+                    durationMillis = durationMillis,
                     delayMillis = initialDelayMillis,
                     easing = AlcoholUnitProgressRingAnimationEasing
                 )

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
@@ -64,6 +64,14 @@ internal fun calculateAlcoholUnitIndicatorOverflowGapRadius(
     return strokeRadius + gapPadding
 }
 
+internal fun resolveAlcoholUnitIndicatorDrawRatio(
+    targetRatio: Float,
+    animatedRatio: Float,
+    animateProgress: Boolean
+): Float {
+    return if (animateProgress) animatedRatio else targetRatio
+}
+
 internal fun alcoholUnitLevelIndicatorColor(alcoholUnitLevel: AlcoholUnitLevel): Color {
     return when (alcoholUnitLevel) {
         is AlcoholUnitLevel.Low -> AlcoholUnitLevelLow

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
@@ -123,6 +123,24 @@ internal fun alcoholUnitLevelIndicatorColor(alcoholUnitLevel: AlcoholUnitLevel):
     }
 }
 
+/**
+ * Draws the shared alcohol unit progress ring.
+ *
+ * Progress animation is opt-in. When [animateProgress] is enabled, the ring animates the
+ * displayed ratio while text and semantics in parent components can continue showing the final
+ * value. A ratio of `1f` means the configured limit; values above `1f` move through the same
+ * over-limit renderer used by static rings, including the cleared overflow gap.
+ *
+ * On first composition, the animated ratio starts at zero and waits [animationStartDelayMillis]
+ * before drawing to the target. Later target changes start immediately from the current displayed
+ * ratio. The duration for each transition is:
+ *
+ * `animationDurationMillis + animationDurationPerRatioMillis * abs(targetRatio - currentRatio)`.
+ *
+ * Use [animationDurationMillis] as the minimum/base time, and
+ * [animationDurationPerRatioMillis] to slow down larger sweeps without making small changes feel
+ * sluggish. Negative timing values are clamped to zero.
+ */
 @Composable
 internal fun AlcoholUnitProgressRing(
     alcoholUnitLevel: AlcoholUnitLevel,

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
@@ -1,9 +1,14 @@
 package com.mgruchala.drinkwise.presentation.common
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -28,6 +33,8 @@ private const val StartAngleDegrees = -90f
 private const val MinimumAlcoholUnitIndicatorLimit = 0.1f
 private const val DayDetailsIndicatorDiameter = 220f
 private const val DayDetailsOverflowGapPadding = 4f
+private const val AlcoholUnitProgressRingAnimationDurationMillis = 800
+private val AlcoholUnitProgressRingAnimationEasing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
 
 // Extra clear radius as a fraction of indicator diameter; 4dp on the 220dp details ring.
 const val AlcoholUnitIndicatorDefaultOverflowGapPaddingFraction =
@@ -86,11 +93,33 @@ internal fun AlcoholUnitProgressRing(
     modifier: Modifier = Modifier,
     trackColor: Color = MaterialTheme.colorScheme.inverseSurface,
     strokeWidth: Dp = 5.dp,
-    overflowGapPaddingFraction: Float = AlcoholUnitIndicatorDefaultOverflowGapPaddingFraction
+    overflowGapPaddingFraction: Float = AlcoholUnitIndicatorDefaultOverflowGapPaddingFraction,
+    animateProgress: Boolean = false
 ) {
-    val ratio = calculateAlcoholUnitIndicatorRatio(
+    val targetRatio = calculateAlcoholUnitIndicatorRatio(
         unitCount = alcoholUnitLevel.unitCount,
         limit = alcoholUnitLevel.limit
+    )
+    val animatedRatio = remember { Animatable(0f) }
+
+    LaunchedEffect(animateProgress, targetRatio) {
+        if (animateProgress) {
+            animatedRatio.animateTo(
+                targetValue = targetRatio,
+                animationSpec = tween(
+                    durationMillis = AlcoholUnitProgressRingAnimationDurationMillis,
+                    easing = AlcoholUnitProgressRingAnimationEasing
+                )
+            )
+        } else {
+            animatedRatio.snapTo(targetRatio)
+        }
+    }
+
+    val ratio = resolveAlcoholUnitIndicatorDrawRatio(
+        targetRatio = targetRatio,
+        animatedRatio = animatedRatio.value,
+        animateProgress = animateProgress
     )
     val levelColor = alcoholUnitLevelIndicatorColor(alcoholUnitLevel)
 

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
@@ -1,11 +1,17 @@
 package com.mgruchala.drinkwise.presentation.common
 
+import android.content.res.Configuration
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -21,12 +27,15 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.mgruchala.drinkwise.domain.AlcoholUnitLevel
 import com.mgruchala.drinkwise.presentation.theme.AlcoholUnitLevelAlarming
 import com.mgruchala.drinkwise.presentation.theme.AlcoholUnitLevelHigh
 import com.mgruchala.drinkwise.presentation.theme.AlcoholUnitLevelLow
+import com.mgruchala.drinkwise.presentation.theme.DrinkWiseTheme
 import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.floor
@@ -271,5 +280,63 @@ private fun DrawScope.drawAlcoholUnitProgress(
             size = Size(radius * 2f, radius * 2f),
             style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
         )
+    }
+}
+
+@Preview(
+    name = "Light",
+    showBackground = true,
+    device = Devices.PIXEL_7_PRO,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+@Composable
+fun AlcoholUnitProgressRingPreviewLightTheme() {
+    AlcoholUnitProgressRingPreview(darkTheme = false)
+}
+
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    device = Devices.PIXEL_7_PRO,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+fun AlcoholUnitProgressRingPreviewDarkTheme() {
+    AlcoholUnitProgressRingPreview(darkTheme = true)
+}
+
+@Composable
+private fun AlcoholUnitProgressRingPreview(darkTheme: Boolean) {
+    DrinkWiseTheme(darkTheme = darkTheme) {
+        Surface(
+            color = MaterialTheme.colorScheme.background,
+            contentColor = MaterialTheme.colorScheme.onBackground
+        ) {
+            Row(
+                modifier = Modifier.padding(24.dp),
+                horizontalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
+                AlcoholUnitProgressRing(
+                    alcoholUnitLevel = AlcoholUnitLevel.Low(1f, 4f),
+                    trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    modifier = Modifier.size(72.dp)
+                )
+                AlcoholUnitProgressRing(
+                    alcoholUnitLevel = AlcoholUnitLevel.Alarming(3.2f, 4f),
+                    trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    modifier = Modifier.size(72.dp)
+                )
+                AlcoholUnitProgressRing(
+                    alcoholUnitLevel = AlcoholUnitLevel.High(5.6f, 4f),
+                    trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    modifier = Modifier.size(72.dp)
+                )
+                AlcoholUnitProgressRing(
+                    alcoholUnitLevel = AlcoholUnitLevel.High(14.8f, 4f),
+                    trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                    modifier = Modifier.size(72.dp)
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/daydetails/components/DayConsumptionIndicator.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/daydetails/components/DayConsumptionIndicator.kt
@@ -83,7 +83,8 @@ fun DayConsumptionIndicator(
             strokeWidth = IndicatorStrokeWidth,
             modifier = Modifier
                 .fillMaxSize(),
-            animateProgress = true
+            animateProgress = true,
+            animationStartDelayMillis = 1000
         )
 
         Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/daydetails/components/DayConsumptionIndicator.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/daydetails/components/DayConsumptionIndicator.kt
@@ -82,7 +82,8 @@ fun DayConsumptionIndicator(
             trackColor = trackColor,
             strokeWidth = IndicatorStrokeWidth,
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxSize(),
+            animateProgress = true
         )
 
         Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/home/DrinksSummaryCard.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/home/DrinksSummaryCard.kt
@@ -62,6 +62,7 @@ fun DrinksSummaryCard(
     forceExpanded: Boolean = false,
     currentMode: CalculationMode,
     onModeChange: (CalculationMode) -> Unit = {},
+    animateInitialProgress: Boolean = true
 ) {
     var expanded by rememberSaveable { mutableStateOf(forceExpanded) }
     Card(
@@ -103,7 +104,8 @@ fun DrinksSummaryCard(
                 AlcoholUnitProgressRing(
                     modifier = Modifier.size(54.dp),
                     alcoholUnitLevel = alcoholUnitLevel,
-                    animateProgress = true
+                    animateProgress = true,
+                    animateInitialProgress = animateInitialProgress
                 )
                 IconButton(
                     onClick = { expanded = !expanded },

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/home/DrinksSummaryCard.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/home/DrinksSummaryCard.kt
@@ -103,6 +103,7 @@ fun DrinksSummaryCard(
                 AlcoholUnitProgressRing(
                     modifier = Modifier.size(54.dp),
                     alcoholUnitLevel = alcoholUnitLevel,
+                    animateProgress = true
                 )
                 IconButton(
                     onClick = { expanded = !expanded },

--- a/app/src/main/java/com/mgruchala/drinkwise/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/mgruchala/drinkwise/presentation/home/HomeScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,11 +31,15 @@ import com.mgruchala.user_preferences.summary_period.CalculationMode
 
 @Composable
 fun HomeScreen(
-    viewModel: HomeScreenViewModel = hiltViewModel()
+    viewModel: HomeScreenViewModel = hiltViewModel(),
+    animateInitialProgress: Boolean = true,
+    onInitialProgressAnimationConsumed: () -> Unit = {}
 ) {
     val state by viewModel.state.collectAsState()
     HomeScreenContent(
         state = state,
+        animateInitialProgress = animateInitialProgress,
+        onInitialProgressAnimationConsumed = onInitialProgressAnimationConsumed,
         registerNewDrinks = viewModel::registerNewDrinks,
         updateDailySummaryPeriod = viewModel::updateDailySummaryCalculationModePreferences,
         updateWeeklySummaryPeriod = viewModel::updateWeeklySummaryCalculationModePreferences,
@@ -49,8 +54,16 @@ fun HomeScreenContent(
     updateDailySummaryPeriod: (CalculationMode) -> Unit = {},
     updateMonthlySummaryPeriod: (CalculationMode) -> Unit = {},
     updateWeeklySummaryPeriod: (CalculationMode) -> Unit = {},
+    animateInitialProgress: Boolean = true,
+    onInitialProgressAnimationConsumed: () -> Unit = {}
 ) {
     val openAddDrinkDialog = rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(animateInitialProgress) {
+        if (animateInitialProgress) {
+            onInitialProgressAnimationConsumed()
+        }
+    }
 
     if (openAddDrinkDialog.value) {
         AddDrinkDialog(
@@ -89,6 +102,7 @@ fun HomeScreenContent(
                     period = DrinkSummaryCardPeriod.DAILY,
                     alcoholUnitLevel = state.todayAlcoholUnitLevel,
                     currentMode = state.dailySummaryCalculationMode,
+                    animateInitialProgress = animateInitialProgress,
                     onModeChange = { calculationMode ->
                         updateDailySummaryPeriod(calculationMode)
                     }
@@ -97,6 +111,7 @@ fun HomeScreenContent(
                     period = DrinkSummaryCardPeriod.WEEKLY,
                     alcoholUnitLevel = state.weekAlcoholUnitLevel,
                     currentMode = state.weeklySummaryCalculationMode,
+                    animateInitialProgress = animateInitialProgress,
                     onModeChange = { calculationMode ->
                         updateWeeklySummaryPeriod(calculationMode)
                     }
@@ -105,6 +120,7 @@ fun HomeScreenContent(
                     period = DrinkSummaryCardPeriod.MONTHLY,
                     alcoholUnitLevel = state.monthAlcoholUnitLevel,
                     currentMode = state.monthlySummaryCalculationMode,
+                    animateInitialProgress = animateInitialProgress,
                     onModeChange = { calculationMode ->
                         updateMonthlySummaryPeriod(calculationMode)
                     }

--- a/app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt
+++ b/app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt
@@ -120,4 +120,26 @@ class AlcoholUnitProgressRingTest {
 
         assertEquals(1.5f, gapRadius, FLOAT_TOLERANCE)
     }
+
+    @Test
+    fun `draw ratio uses target ratio when progress animation is disabled`() {
+        val drawRatio = resolveAlcoholUnitIndicatorDrawRatio(
+            targetRatio = 1.38f,
+            animatedRatio = 0.25f,
+            animateProgress = false
+        )
+
+        assertEquals(1.38f, drawRatio, FLOAT_TOLERANCE)
+    }
+
+    @Test
+    fun `draw ratio uses animated ratio when progress animation is enabled`() {
+        val drawRatio = resolveAlcoholUnitIndicatorDrawRatio(
+            targetRatio = 1.38f,
+            animatedRatio = 0.25f,
+            animateProgress = true
+        )
+
+        assertEquals(0.25f, drawRatio, FLOAT_TOLERANCE)
+    }
 }

--- a/app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt
+++ b/app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt
@@ -142,4 +142,38 @@ class AlcoholUnitProgressRingTest {
 
         assertEquals(0.25f, drawRatio, FLOAT_TOLERANCE)
     }
+
+    @Test
+    fun `animation duration ignores negative values`() {
+        val durationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
+            animationDurationMillis = -300
+        )
+
+        assertEquals(0, durationMillis)
+    }
+
+    @Test
+    fun `initial animation delay ignores negative values`() {
+        val delayMillis = calculateAlcoholUnitIndicatorInitialAnimationDelayMillis(
+            animationStartDelayMillis = -300,
+            isInitialAnimation = true
+        )
+
+        assertEquals(0, delayMillis)
+    }
+
+    @Test
+    fun `initial animation delay is used only for the first animation`() {
+        val initialDelayMillis = calculateAlcoholUnitIndicatorInitialAnimationDelayMillis(
+            animationStartDelayMillis = 300,
+            isInitialAnimation = true
+        )
+        val laterDelayMillis = calculateAlcoholUnitIndicatorInitialAnimationDelayMillis(
+            animationStartDelayMillis = 300,
+            isInitialAnimation = false
+        )
+
+        assertEquals(300, initialDelayMillis)
+        assertEquals(0, laterDelayMillis)
+    }
 }

--- a/app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt
+++ b/app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt
@@ -146,10 +146,44 @@ class AlcoholUnitProgressRingTest {
     @Test
     fun `animation duration ignores negative values`() {
         val durationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
-            animationDurationMillis = -300
+            animationDurationMillis = -300,
+            animationDurationPerRatioMillis = -300,
+            startRatio = 0f,
+            targetRatio = 1f
         )
 
         assertEquals(0, durationMillis)
+    }
+
+    @Test
+    fun `animation duration increases with animated ratio distance`() {
+        val shortDurationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
+            animationDurationMillis = 650,
+            animationDurationPerRatioMillis = 700,
+            startRatio = 0f,
+            targetRatio = 0.3f
+        )
+        val longDurationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
+            animationDurationMillis = 650,
+            animationDurationPerRatioMillis = 700,
+            startRatio = 0f,
+            targetRatio = 1.44f
+        )
+
+        assertEquals(860, shortDurationMillis)
+        assertEquals(1658, longDurationMillis)
+    }
+
+    @Test
+    fun `animation duration uses the distance from the current displayed ratio`() {
+        val durationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
+            animationDurationMillis = 650,
+            animationDurationPerRatioMillis = 700,
+            startRatio = 1.14f,
+            targetRatio = 1.44f
+        )
+
+        assertEquals(860, durationMillis)
     }
 
     @Test

--- a/app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt
+++ b/app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt
@@ -144,6 +144,50 @@ class AlcoholUnitProgressRingTest {
     }
 
     @Test
+    fun `initial animated ratio starts at zero when initial progress animation is enabled`() {
+        val initialRatio = resolveAlcoholUnitIndicatorInitialAnimatedRatio(
+            targetRatio = 1.38f,
+            animateProgress = true,
+            animateInitialProgress = true
+        )
+
+        assertEquals(0f, initialRatio, FLOAT_TOLERANCE)
+    }
+
+    @Test
+    fun `initial animated ratio starts at target when initial progress animation is disabled`() {
+        val initialRatio = resolveAlcoholUnitIndicatorInitialAnimatedRatio(
+            targetRatio = 1.38f,
+            animateProgress = true,
+            animateInitialProgress = false
+        )
+
+        assertEquals(1.38f, initialRatio, FLOAT_TOLERANCE)
+    }
+
+    @Test
+    fun `initial transition does not animate when initial progress animation is disabled`() {
+        val shouldAnimateTransition = shouldAnimateAlcoholUnitIndicatorTransition(
+            animateProgress = true,
+            animateInitialProgress = false,
+            isInitialAnimation = true
+        )
+
+        assertEquals(false, shouldAnimateTransition)
+    }
+
+    @Test
+    fun `later transition animates when initial progress animation is disabled`() {
+        val shouldAnimateTransition = shouldAnimateAlcoholUnitIndicatorTransition(
+            animateProgress = true,
+            animateInitialProgress = false,
+            isInitialAnimation = false
+        )
+
+        assertEquals(true, shouldAnimateTransition)
+    }
+
+    @Test
     fun `animation duration ignores negative values`() {
         val durationMillis = calculateAlcoholUnitIndicatorAnimationDurationMillis(
             animationDurationMillis = -300,

--- a/docs/superpowers/plans/2026-05-23-progress-ring-animation.md
+++ b/docs/superpowers/plans/2026-05-23-progress-ring-animation.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Kotlin, Jetpack Compose Canvas, Compose animation core `Animatable`, Material 3 motion easing, JUnit 5, Gradle, Maestro for Android UI verification.
 
-**Follow-up adjustment:** After reviewing a screen recording, the animation timing was tuned inside `AlcoholUnitProgressRing`: the default duration is slower, the initial draw can start after a short configurable delay, and that delay applies only to the first animation for each ring instance.
+**Follow-up adjustment:** After reviewing a screen recording, the animation timing was tuned inside `AlcoholUnitProgressRing`: the initial draw can start after a short configurable delay, that delay applies only to the first animation for each ring instance, and duration now scales with the animated ratio distance so large over-limit sweeps move more calmly than small changes.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-23-progress-ring-animation.md
+++ b/docs/superpowers/plans/2026-05-23-progress-ring-animation.md
@@ -1,0 +1,376 @@
+# Progress Ring Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in calm draw-on animation to selected alcohol unit progress rings while preserving the existing static default and over-limit Canvas behavior.
+
+**Architecture:** Keep `AlcoholUnitProgressRing` as the single shared renderer. Add local Compose animation state that animates only the displayed ratio before handing it to the existing drawing function, then opt in Home summary cards, the Calendar month summary, and the Day Details large indicator.
+
+**Tech Stack:** Kotlin, Jetpack Compose Canvas, Compose animation core `Animatable`, Material 3 motion easing, JUnit 5, Gradle, Maestro for Android UI verification.
+
+---
+
+## File Structure
+
+- Modify `app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt`
+  - Add animation imports, shared motion constants, an opt-in `animateProgress` parameter, local `Animatable` state, and a small testable ratio-selection helper.
+- Modify `app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt`
+  - Add tests for the ratio-selection helper so static and animated draw paths stay explicit.
+- Modify `app/src/main/java/com/mgruchala/drinkwise/presentation/home/DrinksSummaryCard.kt`
+  - Opt the 54dp Home summary ring into animation.
+- Modify `app/src/main/java/com/mgruchala/drinkwise/presentation/calendar/CalendarScreen.kt`
+  - Opt the large monthly summary ring into animation and leave `DayCell` rings static.
+- Modify `app/src/main/java/com/mgruchala/drinkwise/presentation/daydetails/components/DayConsumptionIndicator.kt`
+  - Opt the 220dp Day Details ring into animation.
+- Use existing verification flows:
+  - `maestro/flows/home-smoke.yaml`
+  - `maestro/flows/calendar-day-details.yaml`
+
+---
+
+### Task 1: Add Test Coverage For Animated Ratio Selection
+
+**Files:**
+- Modify: `app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt`
+- Modify: `app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Add these tests before the closing brace in `AlcoholUnitProgressRingTest`:
+
+```kotlin
+    @Test
+    fun `draw ratio uses target ratio when progress animation is disabled`() {
+        val drawRatio = resolveAlcoholUnitIndicatorDrawRatio(
+            targetRatio = 1.38f,
+            animatedRatio = 0.25f,
+            animateProgress = false
+        )
+
+        assertEquals(1.38f, drawRatio, FLOAT_TOLERANCE)
+    }
+
+    @Test
+    fun `draw ratio uses animated ratio when progress animation is enabled`() {
+        val drawRatio = resolveAlcoholUnitIndicatorDrawRatio(
+            targetRatio = 1.38f,
+            animatedRatio = 0.25f,
+            animateProgress = true
+        )
+
+        assertEquals(0.25f, drawRatio, FLOAT_TOLERANCE)
+    }
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.mgruchala.drinkwise.presentation.common.AlcoholUnitProgressRingTest"
+```
+
+Expected: FAIL with an unresolved reference for `resolveAlcoholUnitIndicatorDrawRatio`.
+
+- [ ] **Step 3: Add the minimal helper implementation**
+
+Add this helper in `AlcoholUnitProgressRing.kt` after `calculateAlcoholUnitIndicatorOverflowGapRadius` and before `alcoholUnitLevelIndicatorColor`:
+
+```kotlin
+internal fun resolveAlcoholUnitIndicatorDrawRatio(
+    targetRatio: Float,
+    animatedRatio: Float,
+    animateProgress: Boolean
+): Float {
+    return if (animateProgress) animatedRatio else targetRatio
+}
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.mgruchala.drinkwise.presentation.common.AlcoholUnitProgressRingTest"
+```
+
+Expected: PASS for all tests in `AlcoholUnitProgressRingTest`.
+
+- [ ] **Step 5: Commit the helper test and implementation**
+
+Run:
+
+```bash
+git add app/src/test/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRingTest.kt app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+git commit -m "test: cover progress ring animation ratio selection"
+```
+
+---
+
+### Task 2: Add Opt-In Animation To The Shared Ring
+
+**Files:**
+- Modify: `app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt`
+
+- [ ] **Step 1: Add Compose animation imports**
+
+Add these imports near the top of `AlcoholUnitProgressRing.kt`:
+
+```kotlin
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+```
+
+- [ ] **Step 2: Add shared motion constants**
+
+Add these constants below `DayDetailsOverflowGapPadding`:
+
+```kotlin
+private const val AlcoholUnitProgressRingAnimationDurationMillis = 800
+private val AlcoholUnitProgressRingAnimationEasing = CubicBezierEasing(0.05f, 0.7f, 0.1f, 1f)
+```
+
+- [ ] **Step 3: Replace the shared ring composable with the animated implementation**
+
+Replace the current `AlcoholUnitProgressRing` composable with:
+
+```kotlin
+@Composable
+internal fun AlcoholUnitProgressRing(
+    alcoholUnitLevel: AlcoholUnitLevel,
+    modifier: Modifier = Modifier,
+    trackColor: Color = MaterialTheme.colorScheme.inverseSurface,
+    strokeWidth: Dp = 5.dp,
+    overflowGapPaddingFraction: Float = AlcoholUnitIndicatorDefaultOverflowGapPaddingFraction,
+    animateProgress: Boolean = false
+) {
+    val targetRatio = calculateAlcoholUnitIndicatorRatio(
+        unitCount = alcoholUnitLevel.unitCount,
+        limit = alcoholUnitLevel.limit
+    )
+    val animatedRatio = remember { Animatable(0f) }
+
+    LaunchedEffect(animateProgress, targetRatio) {
+        if (animateProgress) {
+            animatedRatio.animateTo(
+                targetValue = targetRatio,
+                animationSpec = tween(
+                    durationMillis = AlcoholUnitProgressRingAnimationDurationMillis,
+                    easing = AlcoholUnitProgressRingAnimationEasing
+                )
+            )
+        } else {
+            animatedRatio.snapTo(targetRatio)
+        }
+    }
+
+    val ratio = resolveAlcoholUnitIndicatorDrawRatio(
+        targetRatio = targetRatio,
+        animatedRatio = animatedRatio.value,
+        animateProgress = animateProgress
+    )
+    val levelColor = alcoholUnitLevelIndicatorColor(alcoholUnitLevel)
+
+    Canvas(
+        modifier = modifier
+            .fillMaxSize()
+            .graphicsLayer { alpha = 0.99f }
+    ) {
+        drawAlcoholUnitProgressRing(
+            ratio = ratio,
+            levelColor = levelColor,
+            trackColor = trackColor,
+            strokeWidth = strokeWidth.toPx(),
+            overflowGapPaddingFraction = overflowGapPaddingFraction
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run the targeted test to catch compile regressions**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest --tests "com.mgruchala.drinkwise.presentation.common.AlcoholUnitProgressRingTest"
+```
+
+Expected: PASS for all tests in `AlcoholUnitProgressRingTest`.
+
+- [ ] **Step 5: Commit the shared animation implementation**
+
+Run:
+
+```bash
+git add app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt
+git commit -m "feat: add opt-in progress ring animation"
+```
+
+---
+
+### Task 3: Enable Animation Only On Approved Ring Usages
+
+**Files:**
+- Modify: `app/src/main/java/com/mgruchala/drinkwise/presentation/home/DrinksSummaryCard.kt`
+- Modify: `app/src/main/java/com/mgruchala/drinkwise/presentation/calendar/CalendarScreen.kt`
+- Modify: `app/src/main/java/com/mgruchala/drinkwise/presentation/daydetails/components/DayConsumptionIndicator.kt`
+
+- [ ] **Step 1: Opt in Home summary rings**
+
+In `DrinksSummaryCard.kt`, update the `AlcoholUnitProgressRing` call inside the card row to:
+
+```kotlin
+                AlcoholUnitProgressRing(
+                    modifier = Modifier.size(54.dp),
+                    alcoholUnitLevel = alcoholUnitLevel,
+                    animateProgress = true
+                )
+```
+
+- [ ] **Step 2: Opt in the Calendar month summary ring**
+
+In `CalendarScreen.kt`, update the `AlcoholUnitProgressRing` call inside `MonthConsumptionIndicator` to:
+
+```kotlin
+        AlcoholUnitProgressRing(
+            alcoholUnitLevel = alcoholUnitLevel,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            strokeWidth = MonthConsumptionIndicatorStrokeWidth,
+            modifier = Modifier.fillMaxSize(),
+            animateProgress = true
+        )
+```
+
+- [ ] **Step 3: Keep Calendar day-cell rings static**
+
+Confirm the `AlcoholUnitProgressRing` call inside `DayCell` still has no `animateProgress` argument:
+
+```kotlin
+                AlcoholUnitProgressRing(
+                    modifier = Modifier.matchParentSize(),
+                    alcoholUnitLevel = it,
+                    strokeWidth = 3.dp,
+                )
+```
+
+- [ ] **Step 4: Opt in the Day Details large ring**
+
+In `DayConsumptionIndicator.kt`, update the `AlcoholUnitProgressRing` call to:
+
+```kotlin
+        AlcoholUnitProgressRing(
+            alcoholUnitLevel = alcoholUnitLevel,
+            trackColor = trackColor,
+            strokeWidth = IndicatorStrokeWidth,
+            modifier = Modifier
+                .fillMaxSize(),
+            animateProgress = true
+        )
+```
+
+- [ ] **Step 5: Confirm only three call sites opt in**
+
+Run:
+
+```bash
+rg -n "animateProgress = true|AlcoholUnitProgressRing\\(" app/src/main/java/com/mgruchala/drinkwise/presentation
+```
+
+Expected: `animateProgress = true` appears in exactly these files:
+
+```text
+app/src/main/java/com/mgruchala/drinkwise/presentation/home/DrinksSummaryCard.kt
+app/src/main/java/com/mgruchala/drinkwise/presentation/calendar/CalendarScreen.kt
+app/src/main/java/com/mgruchala/drinkwise/presentation/daydetails/components/DayConsumptionIndicator.kt
+```
+
+Expected: the `DayCell` ring in `CalendarScreen.kt` still calls `AlcoholUnitProgressRing` without `animateProgress = true`.
+
+- [ ] **Step 6: Run app unit tests**
+
+Run:
+
+```bash
+./gradlew test
+```
+
+Expected: PASS for all unit tests.
+
+- [ ] **Step 7: Commit the opt-in call sites**
+
+Run:
+
+```bash
+git add app/src/main/java/com/mgruchala/drinkwise/presentation/home/DrinksSummaryCard.kt app/src/main/java/com/mgruchala/drinkwise/presentation/calendar/CalendarScreen.kt app/src/main/java/com/mgruchala/drinkwise/presentation/daydetails/components/DayConsumptionIndicator.kt
+git commit -m "feat: animate selected progress rings"
+```
+
+---
+
+### Task 4: Verify UI Behavior With Manual And Maestro Checks
+
+**Files:**
+- No code files should change in this task.
+- Existing verification flows: `maestro/flows/home-smoke.yaml`, `maestro/flows/calendar-day-details.yaml`
+
+- [ ] **Step 1: Run the Home smoke flow when an emulator or device is available**
+
+Run:
+
+```bash
+scripts/android-maestro-run.sh maestro/flows/home-smoke.yaml
+```
+
+Expected: PASS, with a `home-smoke` screenshot in the printed `artifacts/maestro/<timestamp>` directory.
+
+If no emulator/device can be used in the execution environment, record this as SKIP with the exact missing dependency or startup error.
+
+- [ ] **Step 2: Run the Calendar and Day Details flow when an emulator or device is available**
+
+Run:
+
+```bash
+scripts/android-maestro-run.sh maestro/flows/calendar-day-details.yaml
+```
+
+Expected: PASS, with `calendar-month-summary` and `calendar-day-details-design` screenshots in the printed `artifacts/maestro/<timestamp>` directory.
+
+If no emulator/device can be used in the execution environment, record this as SKIP with the exact missing dependency or startup error.
+
+- [ ] **Step 3: Manually inspect Home animation behavior**
+
+Open the debug app and verify:
+
+```text
+1. Home initially shows Today, This Week, and This Month ring progress drawing from empty to final state.
+2. Expand Today, switch between Since midnight and Last 24h, and confirm the ring animates from the current displayed state to the new state.
+3. Expand This Week, switch between This week and Last 7 days, and confirm the same transition behavior.
+4. Expand This Month, switch between This month and Last 30 days, and confirm the same transition behavior.
+5. The text values update immediately and do not count up.
+```
+
+- [ ] **Step 4: Manually inspect Calendar and Day Details animation behavior**
+
+Open the debug app and verify:
+
+```text
+1. Calendar month summary ring draws from empty to final state when the month summary first appears.
+2. Calendar day-cell rings do not animate.
+3. Over-limit month summary preserves the existing full base lap, rounded cap, overflow gap, and overflow lap.
+4. Opening a day details page animates the large ring from empty to final state.
+5. Over-limit day details preserves the existing full base lap, rounded cap, overflow gap, overflow lap, and +x label.
+6. Center text and accessibility content describe the final values, not animation frames.
+```
+
+- [ ] **Step 5: Capture final git state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no modified tracked files. Generated Maestro artifacts may appear under `artifacts/` and should remain untracked unless explicitly requested.

--- a/docs/superpowers/plans/2026-05-23-progress-ring-animation.md
+++ b/docs/superpowers/plans/2026-05-23-progress-ring-animation.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Kotlin, Jetpack Compose Canvas, Compose animation core `Animatable`, Material 3 motion easing, JUnit 5, Gradle, Maestro for Android UI verification.
 
-**Follow-up adjustment:** After reviewing a screen recording, the animation timing was tuned inside `AlcoholUnitProgressRing`: the initial draw can start after a short configurable delay, that delay applies only to the first animation for each ring instance, and duration now scales with the animated ratio distance so large over-limit sweeps move more calmly than small changes.
+**Follow-up adjustment:** After reviewing a screen recording, the animation timing was tuned inside `AlcoholUnitProgressRing`: the initial draw can start after a short configurable delay, that delay applies only to the first animation for each ring instance, duration now scales with the animated ratio distance, and Home/Calendar initial draw-on animation is limited to the first app-session entry while later Home period toggles still animate.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-23-progress-ring-animation.md
+++ b/docs/superpowers/plans/2026-05-23-progress-ring-animation.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Kotlin, Jetpack Compose Canvas, Compose animation core `Animatable`, Material 3 motion easing, JUnit 5, Gradle, Maestro for Android UI verification.
 
+**Follow-up adjustment:** After reviewing a screen recording, the animation timing was tuned inside `AlcoholUnitProgressRing`: the default duration is slower, the initial draw can start after a short configurable delay, and that delay applies only to the first animation for each ring instance.
+
 ---
 
 ## File Structure

--- a/docs/superpowers/specs/2026-05-23-progress-ring-animation-design.md
+++ b/docs/superpowers/specs/2026-05-23-progress-ring-animation-design.md
@@ -47,7 +47,7 @@ Out of scope:
 
 Use an opt-in animation parameter on the shared ring component.
 
-`AlcoholUnitProgressRing` remains the single source of truth for ring drawing and overflow behavior. It should expose a parameter such as `animateProgress: Boolean = false`. Existing and future call sites remain static by default unless they explicitly opt in.
+`AlcoholUnitProgressRing` remains the single source of truth for ring drawing and overflow behavior. It should expose a parameter such as `animateProgress: Boolean = false`. Existing and future call sites remain static by default unless they explicitly opt in. The same composable should also expose timing parameters for the draw-on animation so callers can tune duration and the initial start delay without owning animation state.
 
 When `animateProgress` is `false`, the component should behave as it does today: calculate the target ratio from `AlcoholUnitLevel` and draw it immediately.
 
@@ -63,7 +63,10 @@ For opted-in rings:
 - The displayed ratio animates to the target ratio.
 - When the target ratio changes while the composable remains mounted, the displayed ratio animates from the current animated value to the new target ratio.
 - The motion uses a Material-style emphasized decelerate easing: quick at the start, gentle at the end.
-- The duration should be long enough to read as intentional polish but short enough not to delay comprehension. A duration in the 700-900ms range is appropriate for the initial draw-on. The implementation plan may choose one fixed duration, or a small shared constant, as long as all opted-in rings use the same feel.
+- The duration should be long enough to read as intentional polish but short enough not to delay comprehension. A default duration around 1200ms is appropriate after visual review because the original 800ms draw-on was easy to miss.
+- The first draw-on animation may use a short start delay, around 300ms by default, so screen/navigation opening does not hide the beginning of the motion.
+- The start delay applies only to the first animation for that ring instance. Later target changes, such as Home summary period switches, should animate immediately from the current displayed ratio to the new target ratio.
+- Animation duration and initial start delay should be parameters on `AlcoholUnitProgressRing`, with defensive handling for negative values.
 - There is no extra pulse, bounce, overshoot, scale, shimmer, or celebratory effect.
 
 The animation should tolerate all valid ratios:

--- a/docs/superpowers/specs/2026-05-23-progress-ring-animation-design.md
+++ b/docs/superpowers/specs/2026-05-23-progress-ring-animation-design.md
@@ -63,7 +63,8 @@ For opted-in rings:
 - The displayed ratio animates to the target ratio.
 - When the target ratio changes while the composable remains mounted, the displayed ratio animates from the current animated value to the new target ratio.
 - The motion uses a Material-style emphasized decelerate easing: quick at the start, gentle at the end.
-- The duration should be long enough to read as intentional polish but short enough not to delay comprehension. A default duration around 1200ms is appropriate after visual review because the original 800ms draw-on was easy to miss.
+- The duration should be long enough to read as intentional polish but short enough not to delay comprehension. Duration scales with the animated ratio distance so a small 30% draw can finish faster while a 134-144% over-limit draw gets more time.
+- The default timing model combines a base duration with an additional per-ratio duration. Both values should be parameters on `AlcoholUnitProgressRing` so the pacing can stay local to the shared component.
 - The first draw-on animation may use a short start delay, around 300ms by default, so screen/navigation opening does not hide the beginning of the motion.
 - The start delay applies only to the first animation for that ring instance. Later target changes, such as Home summary period switches, should animate immediately from the current displayed ratio to the new target ratio.
 - Animation duration and initial start delay should be parameters on `AlcoholUnitProgressRing`, with defensive handling for negative values.
@@ -169,7 +170,7 @@ Mitigation: accept this as intentional. Text remains truthful and stable; the ri
 
 Risk: very short animations may look like a jump, while long animations may feel sluggish.
 
-Mitigation: use one shared calm draw-on duration and verify on real/emulated devices. Tune only if the first pass feels distracting or too slow.
+Mitigation: use shared distance-based timing with a minimum/base duration and a per-ratio duration, then verify on real/emulated devices. Tune the component defaults only if the pacing feels distracting or too slow.
 
 Risk: Compose animation APIs may trigger unnecessary recomposition.
 

--- a/docs/superpowers/specs/2026-05-23-progress-ring-animation-design.md
+++ b/docs/superpowers/specs/2026-05-23-progress-ring-animation-design.md
@@ -1,0 +1,173 @@
+# Progress Ring Animation Design
+
+## Goal
+
+Add a subtle draw-on animation to selected alcohol unit progress rings so they feel alive when a screen loads or when Home summary periods change, while preserving the existing ring drawing, over-limit behavior, text, and accessibility semantics.
+
+The animation should be a small polish layer, not a new data visualization. It applies to the large or summary indicators where motion adds clarity: Home summary cards, the Calendar month summary, and the Day Details consumption indicator.
+
+## Current Context
+
+Drink Wise is an Android/Kotlin Jetpack Compose app using Material 3, Hilt, Room, DataStore Preferences, Navigation Compose, and `StateFlow`-backed ViewModels.
+
+Relevant existing pieces:
+
+- `AlcoholUnitProgressRing` in `app/src/main/java/com/mgruchala/drinkwise/presentation/common/AlcoholUnitProgressRing.kt` owns the shared Canvas ring renderer, alcohol unit ratio calculation, base progress, overflow lap progress, overflow gap radius, and level color selection.
+- `DrinksSummaryCard` in `app/src/main/java/com/mgruchala/drinkwise/presentation/home/DrinksSummaryCard.kt` uses the shared ring at 54dp for Today, This Week, and This Month.
+- `HomeScreen` lets users switch each summary between start-of-period and rolling-period calculation modes. Those mode changes can alter each card's `AlcoholUnitLevel`.
+- `MonthConsumptionIndicator` in `app/src/main/java/com/mgruchala/drinkwise/presentation/calendar/CalendarScreen.kt` uses the shared ring for the large monthly summary.
+- `DayCell` in `CalendarScreen.kt` also uses the shared ring around individual dates, but those compact rings are dense calendar decoration and should remain static.
+- `DayConsumptionIndicator` in `app/src/main/java/com/mgruchala/drinkwise/presentation/daydetails/components/DayConsumptionIndicator.kt` uses the shared ring for the large daily indicator.
+- `AlcoholUnitProgressRingTest` already covers the deterministic progress and overflow helper math.
+
+No ViewModel, repository, database, user-preference, or alcohol calculation changes are needed. The feature is presentation-only.
+
+## Scope
+
+In scope:
+
+- Add an opt-in animation API to `AlcoholUnitProgressRing`.
+- Animate the displayed ratio from zero to the target ratio on first composition for opted-in rings.
+- Animate the displayed ratio from its current displayed value to the next target ratio when the target changes.
+- Enable the animation on Home summary card rings, the Calendar month summary ring, and the Day Details large ring.
+- Preserve the current Canvas rendering details, including start angle, rounded arc caps, base lap behavior, overflow gap, overflow lap behavior, colors, stroke widths, and layout sizes.
+- Keep existing visible text and accessibility descriptions tied to the final/current data state rather than intermediate animation frames.
+- Verify with JVM tests and existing Maestro flows where an emulator or device is available.
+
+Out of scope:
+
+- Animating Calendar day-cell rings.
+- Animating or counting the center/adjacent text values.
+- Changing the `AlcoholUnitLevel` thresholds, unit calculations, summary-period calculations, or persistence.
+- Redesigning Home cards, Calendar, or Day Details layouts.
+- Adding new over-limit labels to Home or Calendar day cells.
+- Changing the existing over-limit visual language.
+
+## Approved Approach
+
+Use an opt-in animation parameter on the shared ring component.
+
+`AlcoholUnitProgressRing` remains the single source of truth for ring drawing and overflow behavior. It should expose a parameter such as `animateProgress: Boolean = false`. Existing and future call sites remain static by default unless they explicitly opt in.
+
+When `animateProgress` is `false`, the component should behave as it does today: calculate the target ratio from `AlcoholUnitLevel` and draw it immediately.
+
+When `animateProgress` is `true`, the component should animate only the ratio value passed into the existing drawing logic. The renderer should still use the same `drawAlcoholUnitProgressRing` function and helper math so the animated and static rings cannot drift apart.
+
+## Motion Behavior
+
+The chosen motion feel is calm draw-on.
+
+For opted-in rings:
+
+- On first composition, the displayed ratio starts at `0f`.
+- The displayed ratio animates to the target ratio.
+- When the target ratio changes while the composable remains mounted, the displayed ratio animates from the current animated value to the new target ratio.
+- The motion uses a Material-style emphasized decelerate easing: quick at the start, gentle at the end.
+- The duration should be long enough to read as intentional polish but short enough not to delay comprehension. A duration in the 700-900ms range is appropriate for the initial draw-on. The implementation plan may choose one fixed duration, or a small shared constant, as long as all opted-in rings use the same feel.
+- There is no extra pulse, bounce, overshoot, scale, shimmer, or celebratory effect.
+
+The animation should tolerate all valid ratios:
+
+- `0f` remains visually empty.
+- Ratios between `0f` and `1f` draw a partial base lap.
+- `1f` draws a full base lap.
+- Ratios above `1f` move through the existing over-limit rendering as the displayed ratio crosses the limit.
+- Very large over-limit ratios should still use the existing current-lap overflow calculation.
+
+## Over-Limit Behavior
+
+The animation must preserve the existing Compose Canvas over-limit effect.
+
+For final ratios above the limit:
+
+- The base ring becomes a full lap in the level color.
+- The current over-limit lap is drawn from the top of the circle.
+- The cleared moving gap remains at the overflow lap head.
+- The stroke cap, start angle, gap sizing, and full-cycle overflow behavior remain unchanged.
+
+During animation into an over-limit target, it is acceptable and desired for the ring to visibly progress from an under-limit partial arc, to a full base lap, and then into the overflow lap. That makes the over-limit transition understandable without introducing a separate animation path.
+
+## Call-Site Behavior
+
+Home summary cards:
+
+- Today, This Week, and This Month rings opt in to animation.
+- First screen load animates each ring from zero to its current target.
+- Switching a card between start-of-period and rolling-period modes animates from the currently displayed ratio to the newly selected mode's ratio.
+- Card expansion/collapse behavior and segmented controls remain unchanged.
+
+Calendar month summary:
+
+- The large monthly summary ring opts in to animation.
+- Opening Calendar animates the visible month summary from zero to its target.
+- Moving between months may animate each newly composed month summary from zero to its month target. This is acceptable because monthly paging already introduces a larger context change.
+- Individual date rings remain static.
+
+Day Details:
+
+- The large day consumption ring opts in to animation.
+- Opening a date detail page animates the ring from zero to its target.
+- The centered percent/unit text and over-limit label appear with final values immediately, as they do today.
+
+## Component Boundaries
+
+Responsibilities should remain narrow:
+
+- `AlcoholUnitProgressRing`: ratio calculation, optional animation, level color selection, and Canvas ring drawing.
+- Home, Calendar, and Day Details callers: decide whether their usage should animate and keep their existing layout concerns.
+- ViewModels and domain classes: continue exposing the final `AlcoholUnitLevel`; they should not know about animation state.
+
+This keeps animation close to the visual primitive while still making it opt-in per product surface.
+
+## Accessibility
+
+The animation should not create new accessibility announcements or expose transient animation frames.
+
+- Existing content descriptions should continue to describe the final/current consumption state.
+- Calendar day cells remain buttons with date-focused descriptions; their small rings remain decorative and static.
+- Home visible text remains the primary compact summary signal beside the decorative ring.
+- Day Details and Calendar month summaries keep their existing detailed descriptions.
+
+Because the animation is purely visual polish, assistive technologies should not need to track each frame.
+
+## Testing
+
+JVM tests should keep covering deterministic helper behavior in `AlcoholUnitProgressRingTest`.
+
+If the implementation introduces a small helper to choose the displayed ratio behavior or animation target, add focused unit tests for that helper. Do not try to unit-test Compose animation frames through timing-sensitive assertions.
+
+Verification should include:
+
+- `./gradlew test`,
+- visual/manual check of Home initial load and Home summary period toggles,
+- visual/manual check of Calendar month summary, including an over-limit month,
+- visual/manual check of Day Details, including an over-limit day,
+- Maestro verification with existing flows under `maestro/flows/` when an emulator or connected device is available.
+
+Relevant existing Maestro flows:
+
+- `maestro/flows/home-smoke.yaml`,
+- `maestro/flows/calendar-day-details.yaml`,
+- `maestro/flows/calendar-day-details-manage-drinks.yaml` if drink editing is touched or needs regression coverage.
+
+## Risks And Mitigations
+
+Risk: enabling animation by default could make dense Calendar day cells feel noisy or expensive.
+
+Mitigation: keep animation opt-in and leave `animateProgress` defaulted to `false`.
+
+Risk: implementing a separate animated renderer could accidentally change the over-limit gap behavior.
+
+Mitigation: animate only the ratio value and continue using the existing Canvas renderer and helper math for both static and animated rings.
+
+Risk: text and ring can briefly disagree while the ring animates toward the final value.
+
+Mitigation: accept this as intentional. Text remains truthful and stable; the ring is a visual transition toward that state.
+
+Risk: very short animations may look like a jump, while long animations may feel sluggish.
+
+Mitigation: use one shared calm draw-on duration and verify on real/emulated devices. Tune only if the first pass feels distracting or too slow.
+
+Risk: Compose animation APIs may trigger unnecessary recomposition.
+
+Mitigation: keep animation state local to the ring, use standard Compose animation primitives, and avoid propagating per-frame values into parent composables or ViewModels.

--- a/docs/superpowers/specs/2026-05-23-progress-ring-animation-design.md
+++ b/docs/superpowers/specs/2026-05-23-progress-ring-animation-design.md
@@ -27,7 +27,7 @@ No ViewModel, repository, database, user-preference, or alcohol calculation chan
 In scope:
 
 - Add an opt-in animation API to `AlcoholUnitProgressRing`.
-- Animate the displayed ratio from zero to the target ratio on first composition for opted-in rings.
+- Animate the displayed ratio from zero to the target ratio on first composition for opted-in rings when that initial draw-on is enabled.
 - Animate the displayed ratio from its current displayed value to the next target ratio when the target changes.
 - Enable the animation on Home summary card rings, the Calendar month summary ring, and the Day Details large ring.
 - Preserve the current Canvas rendering details, including start angle, rounded arc caps, base lap behavior, overflow gap, overflow lap behavior, colors, stroke widths, and layout sizes.
@@ -59,15 +59,15 @@ The chosen motion feel is calm draw-on.
 
 For opted-in rings:
 
-- On first composition, the displayed ratio starts at `0f`.
-- The displayed ratio animates to the target ratio.
+- On first composition, the displayed ratio starts at `0f` when initial draw-on animation is enabled.
+- Initial draw-on animation can be disabled separately from later target-change animation; in that case first composition snaps to the target ratio.
 - When the target ratio changes while the composable remains mounted, the displayed ratio animates from the current animated value to the new target ratio.
 - The motion uses a Material-style emphasized decelerate easing: quick at the start, gentle at the end.
 - The duration should be long enough to read as intentional polish but short enough not to delay comprehension. Duration scales with the animated ratio distance so a small 30% draw can finish faster while a 134-144% over-limit draw gets more time.
 - The default timing model combines a base duration with an additional per-ratio duration. Both values should be parameters on `AlcoholUnitProgressRing` so the pacing can stay local to the shared component.
-- The first draw-on animation may use a short start delay, around 300ms by default, so screen/navigation opening does not hide the beginning of the motion.
+- The first draw-on animation may use a short start delay, so screen/navigation opening does not hide the beginning of the motion.
 - The start delay applies only to the first animation for that ring instance. Later target changes, such as Home summary period switches, should animate immediately from the current displayed ratio to the new target ratio.
-- Animation duration and initial start delay should be parameters on `AlcoholUnitProgressRing`, with defensive handling for negative values.
+- Animation duration, initial draw-on enablement, and initial start delay should be parameters on `AlcoholUnitProgressRing`, with defensive handling for negative timing values.
 - There is no extra pulse, bounce, overshoot, scale, shimmer, or celebratory effect.
 
 The animation should tolerate all valid ratios:
@@ -96,15 +96,16 @@ During animation into an over-limit target, it is acceptable and desired for the
 Home summary cards:
 
 - Today, This Week, and This Month rings opt in to animation.
-- First screen load animates each ring from zero to its current target.
+- First Home entry in an app session animates each ring from zero to its current target.
+- Later Home entries in the same app session snap directly to the current target to avoid repeated decorative motion.
 - Switching a card between start-of-period and rolling-period modes animates from the currently displayed ratio to the newly selected mode's ratio.
 - Card expansion/collapse behavior and segmented controls remain unchanged.
 
 Calendar month summary:
 
 - The large monthly summary ring opts in to animation.
-- Opening Calendar animates the visible month summary from zero to its target.
-- Moving between months may animate each newly composed month summary from zero to its month target. This is acceptable because monthly paging already introduces a larger context change.
+- First Calendar entry in an app session animates the visible month summary from zero to its target.
+- Later Calendar entries in the same app session snap directly to the current target.
 - Individual date rings remain static.
 
 Day Details:


### PR DESCRIPTION
## Summary

- Adds opt-in draw-on animation to the shared alcohol unit progress ring while keeping static behavior as the default.
- Enables animation on Home summary cards, the Calendar month summary ring, and the Day Details large ring, with Day Details intentionally left outside the new session-gating rule.
- Limits Home and Calendar zero-to-target intro animation to the first app-session entry, while preserving Home period-toggle animations for real state changes.
- Preserves the existing over-limit ring rendering, including the full base lap, overflow lap, and cleared overflow gap.
- Adds tuning documentation and previews so the animation parameters are easier to adjust later.

## Changes

- Added local `Animatable` state to `AlcoholUnitProgressRing` and exposed timing controls for base duration, per-ratio duration, initial start delay, and initial draw-on enablement.
- Made animation duration scale with the distance from the current displayed ratio to the next target ratio, so large over-limit sweeps move more calmly than small changes.
- Added app-session state in navigation so Home and Calendar can skip repeated intro animations after the first visible entry.
- Opted in the approved call sites and left dense Calendar day-cell rings static.
- Added focused JVM tests for draw-ratio selection, initial animated ratio selection, transition gating, timing clamping, distance-based duration, and first-animation delay behavior.
- Added light/dark progress ring previews and local superpowers spec/implementation-plan docs.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "com.mgruchala.drinkwise.presentation.common.AlcoholUnitProgressRingTest"`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew test`
- [x] `PATH="$HOME/.maestro/bin:$PATH" scripts/android-maestro-run.sh maestro/flows/home-smoke.yaml`
- [x] `PATH="$HOME/.maestro/bin:$PATH" scripts/android-maestro-run.sh maestro/flows/calendar-day-details.yaml`
- [x] Screenshots inspected from `artifacts/maestro/20260524-162808` and `artifacts/maestro/20260524-162829`.

Note: local untracked `.playwright-mcp/` was left out of the branch.
